### PR TITLE
Add DIMENSION: Page URL

### DIFF
--- a/data-layer/dimensions/page-url.yml
+++ b/data-layer/dimensions/page-url.yml
@@ -1,0 +1,45 @@
+# Dimension: Page URL
+# Generated: 2026-04-26T06:39:49.636Z
+# Contributed by: swapnamagantius
+
+
+Dimension Name: Page URL
+
+Description: |
+  The full canonical or observed URL of the page viewed, used to categorise content consumption, landing experiences, navigation paths, and on-site performance by exact page location. This dimension typically includes protocol, hostname, path, and may include query parameters depending on implementation rules.
+
+Category: Engagement
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Status: draft
+
+Contributed By: swapnamagantius
+
+Created At: 2026-04-26T06:39:48.545+00:00
+
+
+


### PR DESCRIPTION
**Contributed by**: @swapnamagantius

**Action**: created
**Type**: dimensions

---

The full canonical or observed URL of the page viewed, used to categorise content consumption, landing experiences, navigation paths, and on-site performance by exact page location. This dimension typically includes protocol, hostname, path, and may include query parameters depending on implementation rules.