### PR TITLE
Add DIMENSION: Previous Page

### DIFF
--- a/data-layer/dimensions/previous-page.yml
+++ b/data-layer/dimensions/previous-page.yml
@@ -1,0 +1,45 @@
+# Dimension: Previous Page
+# Generated: 2026-04-26T23:52:45.702Z
+# Contributed by: swapnamagantius
+
+
+Dimension Name: Previous Page
+
+Description: |
+  The page URL, path, title, or canonical page identifier viewed immediately before the current page within the same session. This dimension categorises navigation flow by identifying the prior step in a user's on-site journey and is commonly used to analyse pathing, entry-to-content progression, internal click behaviour, and page-to-page drop-off.
+
+Category: Engagement
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Status: draft
+
+Contributed By: swapnamagantius
+
+Created At: 2026-04-26T23:52:44.417+00:00
+
+
+


### PR DESCRIPTION
**Contributed by**: @swapnamagantius

**Action**: created
**Type**: dimensions

---

The page URL, path, title, or canonical page identifier viewed immediately before the current page within the same session. This dimension categorises navigation flow by identifying the prior step in a user's on-site journey and is commonly used to analyse pathing, entry-to-content progression, internal click behaviour, and page-to-page drop-off.