### PR TITLE
Add DIMENSION: Retention Type

### DIFF
--- a/data-layer/dimensions/retention-type.yml
+++ b/data-layer/dimensions/retention-type.yml
@@ -1,0 +1,45 @@
+# Dimension: Retention Type
+# Generated: 2026-04-28T03:27:20.041Z
+# Contributed by: swapnamagantius
+
+
+Dimension Name: Retention Type
+
+Description: |
+  Classifies the method used to measure user retention by defining the return logic applied to a cohort. It categorises retained users into standard analytical retention frameworks such as classic/unbounded retention, rolling retention, bracketed retention, and strict day-N retention so teams can compare retention results consistently across reports and tools.
+
+Category: Retention
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Status: draft
+
+Contributed By: swapnamagantius
+
+Created At: 2026-04-28T03:27:18.72+00:00
+
+
+


### PR DESCRIPTION
**Contributed by**: @swapnamagantius

**Action**: created
**Type**: dimensions

---

Classifies the method used to measure user retention by defining the return logic applied to a cohort. It categorises retained users into standard analytical retention frameworks such as classic/unbounded retention, rolling retention, bracketed retention, and strict day-N retention so teams can compare retention results consistently across reports and tools.