### PR TITLE
Update DIMENSION: Retention Type

### DIFF
--- a/data-layer/dimensions/retention-type.yml
+++ b/data-layer/dimensions/retention-type.yml
@@ -1,0 +1,54 @@
+# Dimension: Retention Type
+# Generated: 2026-04-28T03:29:20.260Z
+# Contributed by: swapnamagantius
+# Last modified by: swapnamagantius
+
+Dimension Name: Retention Type
+Formula: CASE WHEN retention_logic IN ('classic','unbounded') THEN 'Classic Retention' WHEN retention_logic IN ('rolling') THEN 'Rolling Retention' WHEN retention_logic IN ('bracketed','range') THEN 'Bracketed Retention' WHEN retention_logic IN ('strict','day_n','exact_day') THEN 'Strict Day-N Retention' ELSE 'Other' END
+
+Description: |
+  Classifies the method used to measure user retention by defining the return logic applied to a cohort. It categorises retained users into standard analytical retention frameworks such as classic/unbounded retention, rolling retention, bracketed retention, and strict day-N retention so teams can compare retention results consistently across reports and tools.
+
+Category: Retention
+
+
+Industry: Retail
+
+Priority: High
+
+Core Area: Digital Analytics
+
+Scope: User
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Related Dimensions: [Dimensions: Retention type, Cohort date, Return window, User segment, Metrics: Retained users, Retention rate, Active users, Churn rate, KPIs: D1 retention, D7 retention, D30 retention, Repeat purchase rate]
+
+
+
+Contains PII: No
+
+Status: draft
+
+Contributed By: swapnamagantius
+
+Created At: 2026-04-28T03:27:18.72+00:00
+
+Last Modified By: swapnamagantius
+
+Last Modified At: 2026-04-28T03:29:19.037+00:00
+


### PR DESCRIPTION
**Contributed by**: @swapnamagantius

**Action**: edited
**Type**: dimensions

---

Classifies the method used to measure user retention by defining the return logic applied to a cohort. It categorises retained users into standard analytical retention frameworks such as classic/unbounded retention, rolling retention, bracketed retention, and strict day-N retention so teams can compare retention results consistently across reports and tools.