### PR TITLE
Add METRIC: Begin Checkout

### DIFF
--- a/data-layer/metrics/begin-checkout.yml
+++ b/data-layer/metrics/begin-checkout.yml
@@ -1,0 +1,46 @@
+# Metric: Begin Checkout
+# Generated: 2026-04-29T23:35:42.168Z
+# Contributed by: swapnamagantius
+
+
+Metric Name: Begin Checkout
+Formula: Begin Checkout = COUNT of checkout initiation events where event_name = 'begin_checkout'
+
+Description: |
+  Counts the number of times users initiate the checkout process after adding one or more items to cart. This metric is a critical lower-funnel conversion indicator because it measures progression from shopping intent to purchase intent and helps identify friction between cart and checkout.
+
+Category: Conversion
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Status: draft
+
+Contributed By: swapnamagantius
+
+Created At: 2026-04-29T23:35:40.694+00:00
+
+
+


### PR DESCRIPTION
**Contributed by**: @swapnamagantius

**Action**: created
**Type**: metrics

---

Counts the number of times users initiate the checkout process after adding one or more items to cart. This metric is a critical lower-funnel conversion indicator because it measures progression from shopping intent to purchase intent and helps identify friction between cart and checkout.