### PR TITLE
Add METRIC: Product View

### DIFF
--- a/data-layer/metrics/product-view.yml
+++ b/data-layer/metrics/product-view.yml
@@ -1,0 +1,46 @@
+# Metric: Product View
+# Generated: 2026-04-30T17:22:42.288Z
+# Contributed by: swapnamagantius
+
+
+Metric Name: Product View
+Formula: Product View = COUNT of product detail view events where event_name = 'view_item' (or equivalent product detail view event) and product_id is present
+
+Description: |
+  Counts the number of times a product detail page or product detail view is displayed to a user. This metric is foundational for understanding product interest, merchandising effectiveness, and the top of the commerce conversion funnel. It helps teams evaluate product discovery, traffic quality, and the relationship between product exposure and downstream actions such as add-to-cart, checkout, and purchase.
+
+Category: Engagement
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Status: draft
+
+Contributed By: swapnamagantius
+
+Created At: 2026-04-30T17:22:40.418+00:00
+
+
+


### PR DESCRIPTION
**Contributed by**: @swapnamagantius

**Action**: created
**Type**: metrics

---

Counts the number of times a product detail page or product detail view is displayed to a user. This metric is foundational for understanding product interest, merchandising effectiveness, and the top of the commerce conversion funnel. It helps teams evaluate product discovery, traffic quality, and the relationship between product exposure and downstream actions such as add-to-cart, checkout, and purchase.