### PR TITLE
Add METRIC: Cart Removals

### DIFF
--- a/data-layer/metrics/cart-removals.yml
+++ b/data-layer/metrics/cart-removals.yml
@@ -1,0 +1,46 @@
+# Metric: Cart Removals
+# Generated: 2026-04-30T20:04:48.114Z
+# Contributed by: swapnamagantius
+
+
+Metric Name: Cart Removals
+Formula: Cart Removals = COUNT(remove_from_cart events) where each qualifying event represents a user action that decreases cart quantity or removes a line item from the cart.
+
+Description: |
+  Counts the number of times an item is removed from the shopping cart. This metric helps quantify cart abandonment behavior at the product-interaction level, identify friction in pricing or shipping expectations, and evaluate merchandising, promotion, and checkout experience effectiveness.
+
+Category: Conversion
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Status: draft
+
+Contributed By: swapnamagantius
+
+Created At: 2026-04-30T20:04:46.755+00:00
+
+
+


### PR DESCRIPTION
**Contributed by**: @swapnamagantius

**Action**: created
**Type**: metrics

---

Counts the number of times an item is removed from the shopping cart. This metric helps quantify cart abandonment behavior at the product-interaction level, identify friction in pricing or shipping expectations, and evaluate merchandising, promotion, and checkout experience effectiveness.